### PR TITLE
Sort folder entries in Ruby

### DIFF
--- a/lib/roger_style_guide/helpers/toc_helper.rb
+++ b/lib/roger_style_guide/helpers/toc_helper.rb
@@ -75,7 +75,7 @@ module RogerStyleGuide::Helpers::TocHelper
     # Don't go deeper if we reached max_depth
     return if level >= max_depth
 
-    path.entries.each do |entry|
+    path.entries.sort.each do |entry|
       entry_path = path + entry
 
       # Normalize paths, removing all "." and "_" files


### PR DESCRIPTION
This ensures identical ordering across platforms (not always the case right now on Linux vs macOS).